### PR TITLE
Moved Theme Toggle to Footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,6 +1,7 @@
 ---
 import Social from './Social.astro';
 import Email from './Email.astro';
+import ThemeIcon from './ThemeIcon.astro';
 ---
 <style>
   footer {
@@ -14,4 +15,5 @@ import Email from './Email.astro';
   <Social platform="LinkedIn" username="in/aaron-imbrock/" />
   <Social platform="GitHub" username="aaron-imbrock" />
   <Email platform="Email" username="aaron@sizza.net" />
+  <ThemeIcon />
 </footer>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,10 @@
 ---
 import Navigation from './Navigation.astro';
 import Hamburger from './Hamburger.astro';
-import ThemeIcon from './ThemeIcon.astro';
 ---
 <header>
     <nav>
         <Hamburger />
-        <ThemeIcon />
         <Navigation />
     </nav>
 </header>


### PR DESCRIPTION
It's ugly and I don't like it.
- For now I've moved the SVG icon to the Footer. Aesthetically it does look better there.

In order to determine why the Nav bar doesn't line up with the Title Bar I think it's easiest to just deploy as is and then start with Dev Tools. Looking through the CSS there's many rules affecting `nav` and `nav-links`.